### PR TITLE
Implemented S3 Object Event Notification Lambda that will process my images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,7 +213,7 @@ venv.bak/
 .mypy_cache/
 
 ### VisualStudioCode ###
-.vscode
+.vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json

--- a/dogs-service/.vscode/launch.json
+++ b/dogs-service/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    "configurations": [
+        {
+            "type": "aws-sam",
+            "request": "direct-invoke",
+            "name": "dogs-service:HelloWorldFunction",
+            "invokeTarget": {
+                "target": "template",
+                "templatePath": "${workspaceFolder}/template.yaml",
+                "logicalId": "DogsServiceFunction"
+            },
+            "lambda": {
+                "payload": {},
+                "environmentVariables": {}
+            }
+        }
+    ]
+}

--- a/dogs-service/.vscode/settings.json
+++ b/dogs-service/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "python.analysis.extraPaths": [
+        "${workspaceFolder}/layers/common"
+    ],
+    // keep for older VS Code Python extension compatibility
+    "python.autoComplete.extraPaths": [
+        "${workspaceFolder}/layers/common"
+    ]
+}

--- a/dogs-service/dogs_image_processor_lambda/processor.py
+++ b/dogs-service/dogs_image_processor_lambda/processor.py
@@ -1,7 +1,13 @@
+from dogs_common import logger, tracer, get_config
+
+config = get_config()
+
+@tracer.capture_lambda_handler
+@logger.inject_lambda_context(clear_state=True)
 def lambda_handler(event, context):
-    print("Processing dog image...")
+    logger.info("Processing dog image...")
     
-    print(f"Event: {event}")
+    logger.info(f"Event: {event}")
     
     return {
         'statusCode': 200,

--- a/dogs-service/dogs_image_processor_lambda/processor.py
+++ b/dogs-service/dogs_image_processor_lambda/processor.py
@@ -1,0 +1,9 @@
+def lambda_handler(event, context):
+    print("Processing dog image...")
+    
+    print(f"Event: {event}")
+    
+    return {
+        'statusCode': 200,
+        'body': 'Image processed successfully'
+    }

--- a/dogs-service/dogs_image_processor_lambda/requirements.txt
+++ b/dogs-service/dogs_image_processor_lambda/requirements.txt
@@ -1,0 +1,5 @@
+aws-lambda-powertools>=2.28.0
+aws-xray-sdk
+pydantic>=2.5,<3.0
+pydantic-settings>=2.5,<3.0
+requests

--- a/dogs-service/dogs_image_processor_lambda/requirements.txt
+++ b/dogs-service/dogs_image_processor_lambda/requirements.txt
@@ -1,5 +1,1 @@
-aws-lambda-powertools>=2.28.0
-aws-xray-sdk
-pydantic>=2.5,<3.0
-pydantic-settings>=2.5,<3.0
 requests

--- a/dogs-service/dogs_service_lambda/app.py
+++ b/dogs-service/dogs_service_lambda/app.py
@@ -1,29 +1,22 @@
 import exception_handlers as eh
 
-from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver, Response
 from aws_lambda_powertools.event_handler.openapi.exceptions import RequestValidationError
 from aws_lambda_powertools.event_handler.openapi.params import Path
 from aws_lambda_powertools.event_handler.exceptions import ServiceError
 from aws_lambda_powertools.logging import correlation_paths
 from aws_lambda_powertools.utilities.typing import LambdaContext
-from aws_xray_sdk.core import patch_all
 
 from botocore.exceptions import ClientError, BotoCoreError
-from config import AppConfig
+from dogs_common import get_config, logger, tracer
 from handlers import DogsService, HealthService
 from models import CreateDogResponsePayload, CreateDogRequestPayload, DogInfo, CreateImageRequestPayload, ImageUploadInstructions
 from typing import List
 from typing_extensions import Annotated
 from uuid import UUID
 
-patch_all()
+app_config = get_config()
 
-app_config = AppConfig()
-app_config.maybe_print()
-
-tracer = Tracer()
-logger = Logger(level=app_config.log_level)
 app = APIGatewayRestResolver(enable_validation=True)
 
 dogs_service = None

--- a/dogs-service/dogs_service_lambda/db.py
+++ b/dogs-service/dogs_service_lambda/db.py
@@ -6,7 +6,7 @@ from boto3.dynamodb.conditions import Key
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
-from config import AppConfig
+from dogs_common.config import AppConfig
 from utils import DATETIME_NOW_UTC_FN
 from models import DogDb, CreateDogRequestPayload, ImageDb
 from typing import List

--- a/dogs-service/dogs_service_lambda/handlers.py
+++ b/dogs-service/dogs_service_lambda/handlers.py
@@ -2,7 +2,7 @@ from aws_lambda_powertools.event_handler.exceptions import ServiceError
 from aws_lambda_powertools import Logger
 from datetime import datetime, timezone
 from db import DynamoDBClient
-from config import AppConfig
+from dogs_common.config import AppConfig
 from models import DogDb, CreateDogRequestPayload, CreateDogResponsePayload
 from models import DogInfo, ImageUploadInstructions, CreateImageRequestPayload
 from typing import List, Dict, Any

--- a/dogs-service/dogs_service_lambda/models.py
+++ b/dogs-service/dogs_service_lambda/models.py
@@ -82,7 +82,6 @@ class CreateDogRequestPayload(BaseModel):
     age: int
 
 class CreateDogResponsePayload(BaseModel):
-    user_id: UUID
     dog_id: int
     name: str
     age: int

--- a/dogs-service/dogs_service_lambda/requirements.txt
+++ b/dogs-service/dogs_service_lambda/requirements.txt
@@ -1,5 +1,1 @@
-aws-lambda-powertools>=2.28.0
-aws-xray-sdk
-pydantic>=2.5,<3.0
-pydantic-settings>=2.5,<3.0
 requests

--- a/dogs-service/dogs_service_lambda/s3.py
+++ b/dogs-service/dogs_service_lambda/s3.py
@@ -2,7 +2,7 @@ import boto3
 
 from aws_lambda_powertools import Logger
 from typing import Optional
-from config import AppConfig
+from dogs_common.config import AppConfig
 from utils import is_running_local
 
 class S3Client:

--- a/dogs-service/env.json
+++ b/dogs-service/env.json
@@ -6,5 +6,12 @@
         "S3_ENDPOINT": "http://host.docker.internal:4566",
         "S3_PRESIGN_ENDPOINT": "http://localhost:4566",
         "DOGS_IMAGES_BUCKET": "local-dogs-images"
+    },
+    "DogsImageProcessorFunction": {
+        "LOG_LEVEL": "INFO",
+        "DOGS_TABLE_NAME": "local-dogs-db",
+        "DYNAMODB_ENDPOINT": "http://host.docker.internal:4566",
+        "S3_ENDPOINT": "http://host.docker.internal:4566",
+        "DOGS_IMAGES_BUCKET": "local-dogs-images"
     }
 }

--- a/dogs-service/events/s3_delete_image_ev.json
+++ b/dogs-service/events/s3_delete_image_ev.json
@@ -1,0 +1,41 @@
+{
+  "Records": [
+    {
+      "eventVersion": "2.0",
+      "eventSource": "aws:s3",
+      "awsRegion": "eu-west-1",
+      "eventTime": "2025-09-29T14:35:00.000Z",
+      "eventName": "ObjectRemoved:Delete",
+      "userIdentity": {
+        "principalId": "AIDACKCEVSQ6C2EXAMPLE",
+        "type": "AssumedRole",
+        "arn": "arn:aws:sts::123456789012:assumed-role/dogs-service-prod-DogsServiceFunctionRole-ABCDEFGHIJ/dogs-service-prod-lambda",
+        "accountId": "123456789012"
+      },
+      "requestParameters": {
+        "sourceIPAddress": "203.0.113.42",
+        "bucketName": "dogs-service-prod-images",
+        "key": "users/53bea77a-f2bd-42a0-a445-6c7477fce1c9/dogs/1/images/1.jpg"
+      },
+      "responseElements": {
+        "x-amz-request-id": "5B72A9D7E3F1C8A4",
+        "x-amz-id-2": "ZgRISOwyjmnup8K9QkIBDBhObhkhDZe9wDEJf8gkjjjGxdGc8eQn7ZgZ9pQfQ3nrxYAI5QeY5h"
+      },
+      "s3": {
+        "s3SchemaVersion": "1.0",
+        "configurationId": "testConfigRule",
+        "bucket": {
+          "name": "dogs-service-prod-images",
+          "ownerIdentity": {
+            "principalId": "A3NL1KOZZKTv0w"
+          },
+          "arn": "arn:aws:s3:::dogs-service-prod-images"
+        },
+        "object": {
+          "key": "users/53bea77a-f2bd-42a0-a445-6c7477fce1c9/dogs/1/images/1.jpg",
+          "sequencer": "0A1B2C3D4E5F678902"
+        }
+      }
+    }
+  ]
+}

--- a/dogs-service/events/s3_put_image_ev.json
+++ b/dogs-service/events/s3_put_image_ev.json
@@ -1,0 +1,48 @@
+{
+  "Records": [
+    {
+      "eventVersion": "2.0",
+      "eventSource": "aws:s3",
+      "awsRegion": "eu-west-1",
+      "eventTime": "2025-09-29T13:21:00.000Z",
+      "eventName": "ObjectCreated:Put",
+      "userIdentity": {
+        "principalId": "AIDACKCEVSQ6C2EXAMPLE",
+        "type": "AssumedRole",
+        "arn": "arn:aws:sts::123456789012:assumed-role/dogs-service-prod-DogsServiceFunctionRole-ABCDEFGHIJ/dogs-service-prod-lambda",
+        "accountId": "123456789012"
+      },
+      "requestParameters": {
+        "sourceIPAddress": "203.0.113.42",
+        "bucketName": "dogs-service-prod-images",
+        "key": "users/53bea77a-f2bd-42a0-a445-6c7477fce1c9/dogs/1/images/1.jpg",
+        "x-amz-server-side-encryption": "AES256",
+        "x-amz-storage-class": "STANDARD",
+        "x-amz-content-sha256": "UNSIGNED-PAYLOAD"
+      },
+      "responseElements": {
+        "x-amz-request-id": "4442587FB7D0A2F9",
+        "x-amz-id-2": "MzRISOwyjmnup7K7QkIBDBhObhkhDZe8vDEJf8gkjjjGxdGc7dQn6ZgZ8pQfQ2nqyYAI4PdX4g",
+        "x-amz-server-side-encryption": "AES256",
+        "x-amz-server-side-encryption-aws-kms-key-id": "arn:aws:kms:eu-west-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+      },
+      "s3": {
+        "s3SchemaVersion": "1.0",
+        "configurationId": "testConfigRule",
+        "bucket": {
+          "name": "dogs-service-prod-images",
+          "ownerIdentity": {
+            "principalId": "A3NL1KOZZKTv0w"
+          },
+          "arn": "arn:aws:s3:::dogs-service-prod-images"
+        },
+        "object": {
+          "key": "users/53bea77a-f2bd-42a0-a445-6c7477fce1c9/dogs/1/images/1.jpg",
+          "size": 5242880,
+          "eTag": "d41d8cd98f00b204e9800998ecf8427e",
+          "sequencer": "0A1B2C3D4E5F678901"
+        }
+      }
+    }
+  ]
+}

--- a/dogs-service/layers/common/dogs_common/__init__.py
+++ b/dogs-service/layers/common/dogs_common/__init__.py
@@ -1,0 +1,11 @@
+# dogs_common package
+"""
+Common utilities and configuration for the Dogs Service Lambda functions.
+"""
+
+__version__ = "0.1.0"
+__all__ = ["config", "observability", "get_config", "logger", "tracer"]
+
+# Make key components available at package level
+from .config import get_config, AppConfig
+from .observability import logger, tracer

--- a/dogs-service/layers/common/dogs_common/config.py
+++ b/dogs-service/layers/common/dogs_common/config.py
@@ -70,3 +70,9 @@ class AppConfig(BaseSettings):
     def maybe_print(self):
         if self.log_level.upper() in ["DEBUG", "INFO"]:
             print(self)
+
+@lru_cache(maxsize=1)
+def get_config() -> AppConfig:
+    config = AppConfig()
+    config.maybe_print()
+    return config

--- a/dogs-service/layers/common/dogs_common/observability.py
+++ b/dogs-service/layers/common/dogs_common/observability.py
@@ -1,0 +1,19 @@
+from aws_lambda_powertools import Logger, Tracer
+from aws_xray_sdk.core import patch_all
+from dogs_common.config import get_config
+
+# Apply X-Ray patching early at module import time
+patch_all()
+
+# Get config once at module import time
+_config = get_config()
+
+# Create shared logger and tracer instances with consistent configuration
+logger = Logger(
+    service=_config.powertools_service_name,
+    level=_config.log_level
+)
+
+tracer = Tracer(
+    service=_config.powertools_service_name
+)

--- a/dogs-service/layers/common/requirements.txt
+++ b/dogs-service/layers/common/requirements.txt
@@ -1,0 +1,4 @@
+aws-lambda-powertools
+pydantic
+pydantic-settings
+aws-xray-sdk

--- a/dogs-service/template.yaml
+++ b/dogs-service/template.yaml
@@ -25,7 +25,6 @@ Globals:
       AllowOrigin: "'*'"
 
   Function:
-    Handler: app.lambda_handler
     Runtime: python3.13
     Timeout: 30
     Tracing: Active
@@ -46,6 +45,7 @@ Resources:
     Properties:
       FunctionName: !Sub "${AWS::StackName}-${Stage}-lambda"
       CodeUri: dogs_service_lambda/
+      Handler: app.lambda_handler
       Description: Lambda function for Dogs Service
       Policies:
         - DynamoDBCrudPolicy:
@@ -130,6 +130,57 @@ Resources:
       TimeToLiveSpecification:
         AttributeName: expires_at
         Enabled: true
+  
+  DogsImageProcessorFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "${AWS::StackName}-${Stage}-image-processor-lambda"
+      CodeUri: dogs_image_processor_lambda/
+      Handler: processor.lambda_handler
+      Description: Lambda function for processing dog images uploaded to S3
+      Policies:
+        - AWSXRayDaemonWriteAccess
+        - DynamoDBCrudPolicy:
+            TableName: !Ref DogsTable
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action:
+                - s3:GetObject
+              Resource: !Sub "arn:aws:s3:::${DogsImageBucket}/*"
+      Environment:
+        Variables:
+          POWERTOOLS_SERVICE_NAME: dogs-image-processor
+          DYNAMODB_ENDPOINT: ""
+          DOGS_TABLE_NAME: !Ref DogsTable
+          S3_ENDPOINT: ""
+          DOGS_IMAGES_BUCKET: !Ref DogsImageBucket
+          IMAGE_UPLOAD_MAX_SIZE: !Ref DogsServiceImageMaxSizeParam
+          SUPPORTED_IMAGE_EXTENSIONS: !Ref DogsServiceSupportedImageExtensionsParam
+      Events:
+        OnObjectCreated:
+          Type: S3
+          Properties:
+            Bucket: !Ref DogsImageBucket
+            Events: 
+              - s3:ObjectCreated:*
+              - s3:ObjectRemoved:*
+  
+  DogsImageProcessorDLQ:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "${AWS::StackName}-${Stage}-image-processor-dlq"
+      MessageRetentionPeriod: 1209600
+
+  DogsImageProcessorEventInvokeConfig:
+    Type: AWS::Lambda::EventInvokeConfig
+    Properties:
+      FunctionName: !Ref DogsImageProcessorFunction
+      MaximumRetryAttempts: 2
+      MaximumEventAgeInSeconds: 60
+      DestinationConfig:
+        OnFailure:
+          Destination: !Sub "${DogsImageProcessorDLQ.Arn}"
 
   ApplicationResourceGroup:
     Type: AWS::ResourceGroups::Group

--- a/dogs-service/template.yaml
+++ b/dogs-service/template.yaml
@@ -38,8 +38,28 @@ Globals:
         LOG_LEVEL: INFO
         POWERTOOLS_LOGGER_SAMPLE_RATE: "0.1"
         POWERTOOLS_LOGGER_LOG_EVENT: true
+        DYNAMODB_ENDPOINT: ""
+        DOGS_TABLE_NAME: !Ref DogsTable
+        S3_ENDPOINT: ""
+        S3_PRESIGN_ENDPOINT: ""
+        DOGS_IMAGES_BUCKET: !Sub "${AWS::StackName}-${Stage}-images"
+        IMAGE_UPLOAD_EXPIRATION_SECS: !Ref DogsServiceImageExpirationSecParam
+        IMAGE_UPLOAD_MAX_SIZE: !Ref DogsServiceImageMaxSizeParam
+        SUPPORTED_IMAGE_EXTENSIONS: !Ref DogsServiceSupportedImageExtensionsParam
 
 Resources:
+  CommonLambdaLayer:
+    Type: AWS::Serverless::LayerVersion
+    Metadata:
+      BuildMethod: python3.13
+      BuildArchitecture: x86_64
+    Properties:
+      LayerName: !Sub "${AWS::StackName}-${Stage}-common-layer"
+      Description: Common utilities layer for Dogs Service and Image processing Lambdas
+      ContentUri: layers/common/
+      CompatibleRuntimes:
+        - python3.13
+
   DogsServiceFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -47,6 +67,11 @@ Resources:
       CodeUri: dogs_service_lambda/
       Handler: app.lambda_handler
       Description: Lambda function for Dogs Service
+      Layers:
+        - !Ref CommonLambdaLayer
+      Environment:
+        Variables:
+          POWERTOOLS_SERVICE_NAME: dogs-service
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref DogsTable
@@ -56,23 +81,11 @@ Resources:
             - Effect: Allow
               Action:
                 - s3:PutObject
-              Resource: !Sub "arn:aws:s3:::${DogsImageBucket}/*"
+              Resource: !Sub "arn:aws:s3:::${AWS::StackName}-${Stage}-images/*"
             - Effect: Allow
               Action:
                 - s3:ListBucket
-              Resource: !Sub "arn:aws:s3:::${DogsImageBucket}"
-
-      Environment:
-        Variables:
-          POWERTOOLS_SERVICE_NAME: dogs-service
-          DYNAMODB_ENDPOINT: ""
-          DOGS_TABLE_NAME: !Ref DogsTable
-          S3_ENDPOINT: ""
-          S3_PRESIGN_ENDPOINT: ""
-          DOGS_IMAGES_BUCKET: !Ref DogsImageBucket
-          IMAGE_UPLOAD_EXPIRATION_SECS: !Ref DogsServiceImageExpirationSecParam
-          IMAGE_UPLOAD_MAX_SIZE: !Ref DogsServiceImageMaxSizeParam
-          SUPPORTED_IMAGE_EXTENSIONS: !Ref DogsServiceSupportedImageExtensionsParam
+              Resource: !Sub "arn:aws:s3:::${AWS::StackName}-${Stage}-images"
       Events:
         GetUserDogs:
           Type: Api
@@ -138,25 +151,27 @@ Resources:
       CodeUri: dogs_image_processor_lambda/
       Handler: processor.lambda_handler
       Description: Lambda function for processing dog images uploaded to S3
+      Layers:
+        - !Ref CommonLambdaLayer
+      Environment:
+        Variables:
+          POWERTOOLS_SERVICE_NAME: dogs-image-processor
       Policies:
         - AWSXRayDaemonWriteAccess
         - DynamoDBCrudPolicy:
             TableName: !Ref DogsTable
         - Version: "2012-10-17"
+          Statement: 
+            - Effect: Allow
+              Action:
+                - sqs:SendMessage
+              Resource: !Sub "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${AWS::StackName}-${Stage}-image-processor-dlq"
+        - Version: "2012-10-17"
           Statement:
             - Effect: Allow
               Action:
                 - s3:GetObject
-              Resource: !Sub "arn:aws:s3:::${DogsImageBucket}/*"
-      Environment:
-        Variables:
-          POWERTOOLS_SERVICE_NAME: dogs-image-processor
-          DYNAMODB_ENDPOINT: ""
-          DOGS_TABLE_NAME: !Ref DogsTable
-          S3_ENDPOINT: ""
-          DOGS_IMAGES_BUCKET: !Ref DogsImageBucket
-          IMAGE_UPLOAD_MAX_SIZE: !Ref DogsServiceImageMaxSizeParam
-          SUPPORTED_IMAGE_EXTENSIONS: !Ref DogsServiceSupportedImageExtensionsParam
+              Resource: !Sub "arn:aws:s3:::${AWS::StackName}-${Stage}-images/*"
       Events:
         OnObjectCreated:
           Type: S3
@@ -176,12 +191,25 @@ Resources:
     Type: AWS::Lambda::EventInvokeConfig
     Properties:
       FunctionName: !Ref DogsImageProcessorFunction
+      Qualifier: "$LATEST"
       MaximumRetryAttempts: 2
       MaximumEventAgeInSeconds: 60
       DestinationConfig:
         OnFailure:
-          Destination: !Sub "${DogsImageProcessorDLQ.Arn}"
-
+          Destination: !GetAtt DogsImageProcessorDLQ.Arn
+  
+  DogsServiceLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${AWS::StackName}-${Stage}-lambda"
+      RetentionInDays: 14
+  
+  DogsImageProcessorLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${AWS::StackName}-${Stage}-image-processor-lambda"
+      RetentionInDays: 14
+  
   ApplicationResourceGroup:
     Type: AWS::ResourceGroups::Group
     Properties:


### PR DESCRIPTION
Implemented:

- Separate lambda that reacts on PutObject/DeleteObject events in S3. When client sends images with PutObject, lambda is invoked. For now it's a skeleton lambda but it's purpose will be to update the image status in dynamodb.
- Created a separate layer for both lambdas and share the common logic between them.